### PR TITLE
support for berkshelf config file

### DIFF
--- a/bin/grocery-delivery
+++ b/bin/grocery-delivery
@@ -151,6 +151,7 @@ def upload_changed(repo, checkpoint)
       :config => GroceryDelivery::Config.knife_config,
       :bin => GroceryDelivery::Config.knife_bin,
       :berks_bin => GroceryDelivery::Config.berks_bin,
+      :berks_config => GroceryDelivery::Config.berks_config,
       :role_dir => File.join(base_dir, GroceryDelivery::Config.role_path),
       :cookbook_dirs => GroceryDelivery::Config.cookbook_paths.map do |x|
         File.join(base_dir, x)

--- a/lib/grocery_delivery/config.rb
+++ b/lib/grocery_delivery/config.rb
@@ -44,6 +44,6 @@ module GroceryDelivery
     plugin_path '/etc/gd-plugin.rb'
     berks false
     berks_bin '/opt/chefdk/bin/berks'
-    berks_config ''
+    berks_config nil
   end
 end

--- a/lib/grocery_delivery/config.rb
+++ b/lib/grocery_delivery/config.rb
@@ -44,5 +44,6 @@ module GroceryDelivery
     plugin_path '/etc/gd-plugin.rb'
     berks false
     berks_bin '/opt/chefdk/bin/berks'
+    berks_config ''
   end
 end


### PR DESCRIPTION
berkshelf config is necessary when you want to upload to different chef servers as berkshelf will not honor the knife config specified in gd, instead it will look in default locations like ~/.chef/knife.rb. 

Also see related PR https://github.com/facebook/between-meals/pull/12