### PR TITLE
log to stdout when being run from jenkins

### DIFF
--- a/lib/grocery_delivery/logging.rb
+++ b/lib/grocery_delivery/logging.rb
@@ -39,7 +39,9 @@ module GroceryDelivery
       # `%` in `msg` then ruby will interpret it as a printf string and
       # expect more arguments to log().
       Syslog.log(level, '%s', msg)
-      puts msg if $stdout.tty?
+      # Assuming if env variable 'BUILD NUMBER' exists we're being run
+      # by jenkins or similar tool and want to log to stdout
+      puts msg if $stdout.tty? || !ENV['BUILD_NUMBER'].nil?
     end
 
     def self.debug(msg)


### PR DESCRIPTION
I've been running GD from Jenkins instead of cron for a number reasons, most notably so the team can have visibility into its activity and trigger runs ad-hoc.

This might not be the most elegant way to resolve this, so feel free to suggest a better way to go about it. Was trying to find a solution that wouldn't affect how people are using it already and wouldn't require extra config. 