### PR TITLE
Return status

### DIFF
--- a/bin/grocery-delivery
+++ b/bin/grocery-delivery
@@ -295,4 +295,5 @@ end
 GroceryDelivery::Log.warn($status_msg)
 GroceryDelivery::Hooks.postrun(GroceryDelivery::Config.dry_run, $success,
                                $status_msg)
+exit($success)
 # rubocop:enable GlobalVars


### PR DESCRIPTION
Currently grocery-delivery returns false-positive status, even when errors occur during upload. 
This change returns success variable as final return code.

Address the issue #34 