### PR TITLE
Remove timestamp option

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ standard Ruby.
 All command-line options are available in the config file:
 * dry_run (bool, default: false)
 * debug (bool, default: false)
-* timestamp (bool, default: false)
 * config_file (string, default: `/etc/gd-config.rb`)
 * lockfile (string, default: `/var/lock/subsys/grocery_delivery`)
 * pidfile (string, default: `/var/run/grocery_delivery.pid`)

--- a/bin/grocery-delivery
+++ b/bin/grocery-delivery
@@ -190,9 +190,6 @@ def setup_config
         options[:verbosity] = ::Logger::INFO
       end
     end
-    opts.on('-T', '--timestamp', 'Timestamp output') do |s|
-      options[:timestamp] = s
-    end
     opts.on('-c', '--config-file FILE', 'config file') do |s|
       unless File.exists?(File.expand_path(s))
         GroceryDelivery::Log.error("Config file #{s} not found.")

--- a/bin/grocery-delivery
+++ b/bin/grocery-delivery
@@ -282,7 +282,7 @@ else
     write_checkpoint(ver)
     $success = true
     $status_msg = "Success at #{ver}"
-  rescue => e
+  rescue StandardError => e
     $status_msg = e.message
     e.backtrace.each do |line|
       GroceryDelivery::Log.error(line)

--- a/grocery_delivery.gemspec
+++ b/grocery_delivery.gemspec
@@ -10,12 +10,12 @@ Gem::Specification.new do |s|
             Dir.glob('bin/*')
   s.executables = 'grocery-delivery'
   s.license = 'Apache'
-  s.add_dependency 'mixlib-config'
   s.add_dependency 'between_meals', '>= 0.0.6'
+  s.add_dependency 'mixlib-config'
   %w{
-    rubocop
-    knife-solo
     chef-zero
+    knife-solo
+    rubocop
   }.each do |dep|
     s.add_development_dependency dep
   end

--- a/lib/grocery_delivery/config.rb
+++ b/lib/grocery_delivery/config.rb
@@ -26,7 +26,6 @@ module GroceryDelivery
     stdout false
     dry_run false
     verbosity Logger::WARN
-    timestamp false
     config_file '/etc/gd-config.rb'
     pidfile '/var/run/grocery_delivery.pid'
     lockfile '/var/lock/subsys/grocery_delivery'


### PR DESCRIPTION
It was never implemented and is confusing to users. Syslog provides the
timestamps users want.

Closes #37