### PR TITLE
Fix tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,15 @@ language: ruby
 sudo: false
 
 rvm:
-  - 2.2.0
   - 2.3.0
+  - 2.4.1
 
 gemfile:
   - Gemfile
+
+before_script:
+  - gem update --system
+  - bundle update
 
 script:
   - bundle exec rubocop

--- a/grocery_delivery.gemspec
+++ b/grocery_delivery.gemspec
@@ -12,11 +12,15 @@ Gem::Specification.new do |s|
   s.license = 'Apache'
   s.add_dependency 'between_meals', '>= 0.0.6'
   s.add_dependency 'mixlib-config'
-  %w{
-    chef-zero
-    knife-solo
-    rubocop
-  }.each do |dep|
+  [
+    'rubocop',
+    # tests spin up a chef-zero instance
+    'chef-zero',
+    # and the tests need knife
+    'chef-dk',
+    # to work around https://github.com/chef/chef/issues/7383
+    'openssl',
+  ].each do |dep|
     s.add_development_dependency dep
   end
 end

--- a/test/run-git.sh
+++ b/test/run-git.sh
@@ -4,6 +4,7 @@ set -e
 set -o verbose
 bundle exec chef-zero &
 ZERO=$!
+trap "kill -9 $ZERO" EXIT
 SOURCE=/tmp/source
 sleep 5
 
@@ -45,4 +46,3 @@ gd
 )
 gd
 
-kill -9 $ZERO

--- a/test/run-svn.sh
+++ b/test/run-svn.sh
@@ -4,6 +4,7 @@ set -e
 set -o verbose
 bundle exec chef-zero &
 ZERO=$!
+trap "kill -9 $ZERO" EXIT
 SOURCE=/tmp/source
 sleep 5
 
@@ -49,4 +50,3 @@ gd
 )
 gd
 
-kill -9 $ZERO


### PR DESCRIPTION
* Use `trap` so we don't leave chef-zero's around when we fail
* Update the systems so we work around openssl bugs
* Use chef-dk instead of knife-solo for ruby 2.4 compat