### PR TITLE
Expose level the same way as the Logger class

### DIFF
--- a/lib/grocery_delivery/logging.rb
+++ b/lib/grocery_delivery/logging.rb
@@ -29,6 +29,10 @@ module GroceryDelivery
       @@init = true
     end
 
+    def self.level
+      @@level
+    end
+
     def self.verbosity=(val)
       @@level = val
     end


### PR DESCRIPTION
New version of the between meals library checks the logger level passed to it in order to determine how verbose knife commands should be. This works well with project using the Logger class as it exposes the level variable, however, as grocery-delivery passes there a wrapper module that provides sort of the same interface as the Logger class, but does not expose the level, it fails.
With this change, it will be able to determine the level, and work as expected.