### PR TITLE
Convert logging message to a string before prepending severity

### DIFF
--- a/lib/grocery_delivery/logging.rb
+++ b/lib/grocery_delivery/logging.rb
@@ -52,25 +52,25 @@ module GroceryDelivery
 
     def self.debug(msg)
       if @@level == Logger::DEBUG
-        msg.prepend('DEBUG: ')
+        msg.to_s.prepend('DEBUG: ')
         logit(Syslog::LOG_DEBUG, msg)
       end
     end
 
     def self.info(msg)
       if @@level == Logger::INFO
-        msg.prepend('INFO: ')
+        msg.to_s.prepend('INFO: ')
         logit(Syslog::LOG_INFO, msg)
       end
     end
 
     def self.warn(msg)
-      msg.prepend('WARN: ')
+      msg.to_s.prepend('WARN: ')
       logit(Syslog::LOG_WARNING, msg)
     end
 
     def self.error(msg)
-      msg.prepend('ERROR: ')
+      msg.to_s.prepend('ERROR: ')
       logit(Syslog::LOG_ERR, msg)
     end
   end


### PR DESCRIPTION
Logging wrapper expects to get a message as a string, so it prepends a severity to it. However, libraries may pass object instances, that are not descendants of the string, so they do not have the prepend method.
This works fine with normal logger, as it converts the input to the string, so do this in the wrapper as well.