### PR TITLE
Fix reading checkpoint from empty file

### DIFF
--- a/bin/grocery-delivery
+++ b/bin/grocery-delivery
@@ -62,7 +62,8 @@ end
 
 def read_checkpoint
   GroceryDelivery::Log.debug("Reading #{checkpoint_path}")
-  File.exist?(checkpoint_path) ? File.read(checkpoint_path).strip : nil
+  checkpoint = File.exist?(checkpoint_path) ? File.read(checkpoint_path).strip : nil
+  checkpoint.empty? ? nil : checkpoint
 end
 
 def full_upload(knife)

--- a/bin/grocery-delivery
+++ b/bin/grocery-delivery
@@ -62,7 +62,8 @@ end
 
 def read_checkpoint
   GroceryDelivery::Log.debug("Reading #{checkpoint_path}")
-  checkpoint = File.exist?(checkpoint_path) ? File.read(checkpoint_path).strip : nil
+  return nil unless File.exist?(checkpoint_path)
+  checkpoint = File.read(checkpoint_path).strip
   checkpoint.empty? ? nil : checkpoint
 end
 


### PR DESCRIPTION
In case revision checkpoint file gets corrupted the checkpoint is equal to empty string which signals to update cookbooks instead of re-loading them all to ensure validity as it is done if checkpoint file is missing.