### PR TITLE
Write checkpoint files atomically

### DIFF
--- a/bin/grocery-delivery
+++ b/bin/grocery-delivery
@@ -56,8 +56,14 @@ def checkpoint_path
             GroceryDelivery::Config.rev_checkpoint)
 end
 
+def atomic_write(path, content)
+  new_path = path + '.new'
+  File.write(new_path, content)
+  File.rename(new_path, path)
+end
+
 def write_checkpoint(rev)
-  File.write(checkpoint_path, rev) unless GroceryDelivery::Config.dry_run
+  atomic_write(checkpoint_path, rev) unless GroceryDelivery::Config.dry_run
 end
 
 def read_checkpoint


### PR DESCRIPTION
If GD process terminates abruptly it's possible to get corrupted checkpoint files. To prevent this perform the usual trick: write to a temporary file and rename it.