### PR TITLE
Use chef-cookbooks rubocop 0.55 config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,2 +1,2 @@
 inherit_from:
-  - https://raw.githubusercontent.com/facebook/chef-cookbooks/master/.rubocop_55.yml
+  - https://raw.githubusercontent.com/facebook/chef-cookbooks/main/.rubocop_55.yml


### PR DESCRIPTION
This is an intermediate step until chef-cookbooks (and then grocery-delivery) is moved to a new Rubocop version