### PR TITLE
Add new config option for no_update

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ standard Ruby.
 
 All command-line options are available in the config file:
 * dry_run (bool, default: false)
+* no_update (bool, default: false)
 * debug (bool, default: false)
 * config_file (string, default: `/etc/gd-config.rb`)
 * lockfile (string, default: `/var/lock/subsys/grocery_delivery`)

--- a/bin/grocery-delivery
+++ b/bin/grocery-delivery
@@ -254,7 +254,7 @@ GroceryDelivery::Hooks.prerun(GroceryDelivery::Config.dry_run)
 
 if repo.exists?
   action('Updating repo')
-  repo.update unless GroceryDelivery::Config.dry_run
+  repo.update unless (GroceryDelivery::Config.dry_run || GroceryDelivery::Config.no_update)
 else
   unless GroceryDelivery::Config.repo_url
     GroceryDelivery::Log.error(

--- a/bin/grocery-delivery
+++ b/bin/grocery-delivery
@@ -190,6 +190,9 @@ def setup_config
     opts.on('-n', '--dry-run', 'Dryrun mode') do |s|
       options[:dry_run] = s
     end
+    opts.on('-u', '--no-update', 'Do not update local repository') do |s|
+      options[:no_update] = s
+    end
     opts.on('-v', '--verbosity', 'Verbosity level. Twice for debug.') do
       # If -vv is supplied this block is executed twice
       if options[:verbosity]

--- a/grocery_delivery.gemspec
+++ b/grocery_delivery.gemspec
@@ -14,7 +14,7 @@
 
 Gem::Specification.new do |s|
   s.name = 'grocery_delivery'
-  s.version = '0.0.9'
+  s.version = '0.0.10'
   s.summary = 'Grocery Delivery'
   s.description = 'Utility for keeping Chef servers in sync with a repo'
   s.license = 'Apache-2.0'

--- a/lib/grocery_delivery/config.rb
+++ b/lib/grocery_delivery/config.rb
@@ -25,6 +25,7 @@ module GroceryDelivery
     extend Mixlib::Config
     stdout false
     dry_run false
+    no_update false
     verbosity Logger::WARN
     config_file '/etc/gd-config.rb'
     pidfile '/var/run/grocery_delivery.pid'


### PR DESCRIPTION
This pull request will add a new config option (`no_update` via `gd-config.rb`; `--no-update` via CLI) to `grocery-delivery` which will skip the call to `repo.update`. This change is a no-op as `no_update` defaults to `false`).

Context: This change is targeted at those that want to run Grocery Delivery within a container. The new `no_update` config option is desirable insofar that in some deployment workflows where the build system clones the repository's main branch directly to the build host and then executes the build steps to deploy the cookbooks via a Grocery Delivery container. In such a deployment workflow, one could then configure their build/deployment process to copy the entire repo into the container (whereby Grocery Delivery would be invoked). When using this style of deployment workflow, there is no need to update the local clone of the cookbook repository to ensure it is up-to-date (furthermore, the host's container might not be configured to have access to the VCS).