### PR TITLE
[github] Remove Ruby 2.5+2,6 tests, add Ruby 3.0+3.1 tests, update dev gems

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['2.7']
+        ruby: ['2.7', '3.0', '3.1']
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
         ruby-version: ${{ matrix.ruby }}
     - name: Install dependencies
       run: bundle install
+    - name: Install subversion for functional tests
+      run: sudo apt-get install -y subversion
     - name: Run rspec
       run: bundle exec rspec
     - name: Run rubocop

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.5, 2.6, 2.7]
+        ruby: ['2.7']
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ test/syntaxcache/
 .vagrant
 .bundle
 .bundler
+.rubocop-https*

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ group :development, :test do
   gem 'rspec-core', '>= 3.0.0'
   gem 'rspec-expectations', '>= 3.0.0'
   gem 'rspec-mocks', '>= 3.0.0'
-  gem 'rubocop', '= 1.3.1'
+  gem 'rubocop', '= 1.25.1'
   gem 'rugged'
   gem 'simplecov'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gemspec
 group :development, :test do
   gem 'between_meals', :git => 'https://github.com/facebook/between-meals'
   gem 'chef', '= 16.18.0'
-  gem 'chef-zero'
+  gem 'chef-zero', '>= 15.0.11'
   gem 'openssl'
   gem 'rspec-core', '>= 3.0.0'
   gem 'rspec-expectations', '>= 3.0.0'
@@ -13,4 +13,5 @@ group :development, :test do
   gem 'rubocop', '= 1.25.1'
   gem 'rugged'
   gem 'simplecov'
+  gem 'webrick' # chef-zero dep
 end

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gemspec
 
 group :development, :test do
   gem 'between_meals', :git => 'https://github.com/facebook/between-meals'
-  gem 'chef-dk', '~> 3.13.0'
+  gem 'chef', '= 16.18.0'
   gem 'chef-zero'
   gem 'openssl'
   gem 'rspec-core', '>= 3.0.0'

--- a/grocery_delivery.gemspec
+++ b/grocery_delivery.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.bindir = %w{bin}
   s.executables = %w{grocery-delivery}
 
-  s.required_ruby_version = '>= 2.5.0'
+  s.required_ruby_version = '>= 2.7.0'
   s.add_dependency 'between_meals', '>= 0.0.11'
   s.add_dependency 'mixlib-config'
 end


### PR DESCRIPTION
Several smaller commits in one PR (check the commits tab for blow-by-blow), setting the stage for getting this stuff on modern versions

- Ignore local copy of rubocop config
- Bump actions/checkout to get rid of CI errors
- Bump rubocop to same version as facebook/chef-cookbooks
- Remove chef-dk (it's super dead now)
- Explicitly use chef-zero >=15, since it's needed for Ruby 3