### PR TITLE
Use BetweenMeals repository loading for requires

### DIFF
--- a/bin/grocery-delivery
+++ b/bin/grocery-delivery
@@ -17,8 +17,7 @@
 
 require 'between_meals/util'
 require 'between_meals/knife'
-require 'between_meals/repo/svn'
-require 'between_meals/repo/git'
+require 'between_meals/repo'
 require 'between_meals/changeset'
 require 'grocery_delivery/config'
 require 'grocery_delivery/logging'


### PR DESCRIPTION
This allows the lazy loading committed in https://github.com/dafyddcrosby/between-meals/commit/e02a7ca003f44a8ad801517b5c8074f0f4a33027 (it's similar to the work already done in Taste Tester with https://github.com/facebook/taste-tester/commit/0110ffaec5fa49a059a047704594a94fa6e7adbf)