### PR TITLE
[CI] Fix missing rugged dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,5 +11,6 @@ group :development, :test do
   gem 'rspec-expectations', '>= 3.0.0'
   gem 'rspec-mocks', '>= 3.0.0'
   gem 'rubocop', '= 1.3.1'
+  gem 'rugged'
   gem 'simplecov'
 end


### PR DESCRIPTION
https://github.com/facebook/between-meals/commit/fdc6449a96632bb3e0b5156f6a3ce38e84ed79ac removed rugged from the list of default bundled gems, but we use it for the GH CI actions.