### PR TITLE
[github CI] Use actions/checkout@v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Setup Ruby
       uses: ruby/setup-ruby@v1
       with:
@@ -32,7 +32,7 @@ jobs:
 #    runs-on: ubuntu-latest
 #    steps:
 #    - name: Checkout repository
-#      uses: actions/checkout@v2
+#      uses: actions/checkout@v4
 #    - name: Run Rubocop Linter
 #      uses: andrewmcodes/rubocop-linter-action@v3.2.0
 #      env:
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Lint Markdown
       uses: actionshub/markdownlint@1.2.0
     - name: Check links


### PR DESCRIPTION
Trivial fix for https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/